### PR TITLE
Allow ember-admin store adapter's namespace override

### DIFF
--- a/addon/mixins/services/admin.js
+++ b/addon/mixins/services/admin.js
@@ -1,15 +1,11 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-  initStore: Ember.on('init', function() {
-    this.set('store', this.container.lookup('store:admin'));
-  }),
-
-  store: null,
-
   includedModels:  null,
   excludedModels:  null,
 
   includedColumns: null,
-  excludedColumns: null
+  excludedColumns: null,
+
+  namespace: 'admin'
 });

--- a/addon/stores/admin.js
+++ b/addon/stores/admin.js
@@ -1,21 +1,35 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 
 export default DS.Store.extend({
   adapterFor: function(type) {
+    if (!this.typeAdapter) {
+      this.typeAdapter = {};
+    }
     if (!this.typeAdapter[type]) {
-      var adapter = this._super(type);
       var namespaces = [];
+      var adapter = this._super(type);
+      var adminService = this.container.lookup('service:admin');
+
       if (adapter.namespace) {
         namespaces = adapter.namespace.split('/');
       }
-      namespaces.push('admin');
+
+      namespaces.push(adminService.namespace);
+
+      var namespace = namespaces.join('/');
+
+      if (Ember.isEmpty(namespace)) {
+        namespace = undefined;
+      }
+
       var AdminAdapter = adapter.constructor.extend({
-        namespace: namespaces.join('/')
+        namespace: namespace
       });
+
       this.typeAdapter[type] = AdminAdapter.create();
     }
 
     return this.typeAdapter[type];
   },
-  typeAdapter: {}
 });

--- a/app/initializers/admin.js
+++ b/app/initializers/admin.js
@@ -7,5 +7,6 @@ export default {
     app.inject('route', 'admin', 'service:admin');
     app.inject('controller', 'admin', 'service:admin');
     app.inject('component', 'admin', 'service:admin');
+    app.inject('service:admin', 'store', 'store:admin');
   }
 };

--- a/tests/unit/admin-store-test.js
+++ b/tests/unit/admin-store-test.js
@@ -1,0 +1,50 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+import AdminStore from 'ember-admin/stores/admin';
+import AdminService from 'dummy/services/admin';
+
+var oldNamespace, adminStore, adminService;
+
+module('Admin Store', {
+  setup: function() {
+    adminService = AdminService.create({
+      container: {
+        lookup: Ember.K
+      }
+    });
+    adminStore = AdminStore.create({
+      container: {
+        lookup: function(fullName) {
+          if (fullName === 'service:admin') {
+            return adminService;
+          }
+        }
+      }
+    });
+    adminStore.set('defaultAdapter', DS.RESTAdapter.create());
+    adminStore.set('admin', adminService);
+  }
+});
+
+test('defaults to "api" namespace', function() {
+  var adapter = adminStore.adapterFor('dog');
+  equal(adapter.namespace, 'admin');
+});
+
+test('appends ember-admin\'s namespace to the end of the adapter namespaces', function() {
+  adminStore.set('defaultAdapter', DS.RESTAdapter.create({namespace: 'api/v1'}));
+  var adapter = adminStore.adapterFor('dog');
+  equal(adapter.namespace, 'api/v1/admin');
+});
+
+test('allow overriding of default namespace', function() {
+  adminService.namespace = 'hobbes';
+  var adapter = adminStore.adapterFor('dog');
+  equal(adapter.namespace, 'hobbes');
+});
+
+test('allow `null` namespace', function() {
+  adminService.namespace = undefined;
+  var adapter = adminStore.adapterFor('dog');
+  equal(adapter.namespace, undefined);
+});


### PR DESCRIPTION
Closes #25

You can now re-open the `service:admin` object and change the value of
`namespace`. If it is set to `Ember.isEmpty(namepace) === true` it will
set to `undefined` in the created adapter.

Also adds some unit tests for the `store:admin`.
