### PR TITLE
Remove traling slashes from namespace if present

### DIFF
--- a/addon/stores/admin.js
+++ b/addon/stores/admin.js
@@ -18,6 +18,7 @@ export default DS.Store.extend({
       namespaces.push(adminService.namespace);
 
       var namespace = namespaces.join('/');
+      namespace = namespace.replace(/\/$/, '');
 
       if (Ember.isEmpty(namespace)) {
         namespace = undefined;

--- a/tests/unit/admin-store-test.js
+++ b/tests/unit/admin-store-test.js
@@ -4,6 +4,7 @@ import AdminStore from 'ember-admin/stores/admin';
 import AdminService from 'dummy/services/admin';
 
 var oldNamespace, adminStore, adminService;
+var set = Ember.set;
 
 module('Admin Store', {
   setup: function() {
@@ -21,8 +22,8 @@ module('Admin Store', {
         }
       }
     });
-    adminStore.set('defaultAdapter', DS.RESTAdapter.create());
-    adminStore.set('admin', adminService);
+    set(adminStore, 'defaultAdapter', DS.RESTAdapter.create());
+    set(adminStore, 'admin', adminService);
   }
 });
 
@@ -32,7 +33,7 @@ test('defaults to "api" namespace', function() {
 });
 
 test('appends ember-admin\'s namespace to the end of the adapter namespaces', function() {
-  adminStore.set('defaultAdapter', DS.RESTAdapter.create({namespace: 'api/v1'}));
+  set(adminStore, 'defaultAdapter', DS.RESTAdapter.create({namespace: 'api/v1'}));
   var adapter = adminStore.adapterFor('dog');
   equal(adapter.namespace, 'api/v1/admin');
 });
@@ -47,4 +48,11 @@ test('allow `null` namespace', function() {
   adminService.namespace = undefined;
   var adapter = adminStore.adapterFor('dog');
   equal(adapter.namespace, undefined);
+});
+
+test('empty admin namespace does not add tralining slash to adapter namespace', function() {
+  set(adminStore, 'defaultAdapter', DS.RESTAdapter.create({namespace: 'api/v1'}));
+  adminService.namespace = '';
+  var adapter = adminStore.adapterFor('dog');
+  equal(adapter.namespace, 'api/v1');
 });


### PR DESCRIPTION
When you provide an empty string for the admin namespace, but provided a namespace within your adapter then you get a resulting namespace with a trailing slash which leads to generate a url with two slashes.

Example:
application adapter namespace:

```
namespace: 'api/v1',
host: 'http://localhost:1337'
```

admin namespace:
`namespace: ''`
leads to `http://localhost:1337/api/v1//model`

The replace makes sure that the last slash in the namespace gets removed and this then leads to the correct url `http://localhost:1337/api/v1/model`
