### PR TITLE
Avoid calling `bind` helper directly.

### DIFF
--- a/addon/components/property-print.js
+++ b/addon/components/property-print.js
@@ -1,12 +1,28 @@
 import Ember from 'ember';
+import layout from '../templates/property-print';
 
 var get = Ember.get;
+var computed = Ember.computed;
+var observer = Ember.observer;
+var addObserver = Ember.addObserver;
 
 export default Ember.Component.extend({
-  defaultLayout: function(context, options){
-    var path = 'record.' + get(context, 'column');
+  setupCellObsever: observer('record', 'column', function() {
+    var record = get(this, 'record');
+    var column = get(this, 'column');
 
-    options.hash = {};
-    Ember.Handlebars.helpers['bind'].call(context, path, options);
-  }
+    if (!record || !column) { return; } // might want to teardown
+
+    addObserver(this, 'record.' + column, this, this._updateCell);
+  }).on('init')
+
+  _updateCell: function() {
+    var record = get(this, 'record');
+    var column = get(this, 'column');
+    var value = get(record, column);
+
+    set(this, 'cellValue', value);
+  },
+
+  defaultLayout: layout
 });

--- a/addon/templates/property-print.hbs
+++ b/addon/templates/property-print.hbs
@@ -1,0 +1,1 @@
+{{cellValue}}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "ember-cli-async-button": "0.4.0",
+    "ember-cli-htmlbars": "0.7.4",
     "ember-data-route": "0.0.2"
   },
   "devDependencies": {
@@ -29,7 +30,6 @@
     "ember-cli-app-version": "0.3.1",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.7",
-    "ember-cli-htmlbars": "0.7.4",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.8",

--- a/tests/helpers/equality-helpers.js
+++ b/tests/helpers/equality-helpers.js
@@ -1,8 +1,7 @@
 export { rowValuesEqual, inputPropertiesEqual };
 
-function rowValuesEqual (assert) {
-  var row = arguments[0];
-  var values = Array.prototype.slice.call(arguments, 1, arguments.length);
+function rowValuesEqual (assert, row) {
+  var values = Array.prototype.slice.call(arguments, 2, arguments.length);
   var columns = row.find('th, td');
   var columnText;
 
@@ -14,9 +13,8 @@ function rowValuesEqual (assert) {
   }
 }
 
-function inputPropertiesEqual(assert) {
-  var inputs = arguments[0];
-  var values = Array.prototype.slice.call(arguments, 1, arguments.length);
+function inputPropertiesEqual(assert, inputs) {
+  var values = Array.prototype.slice.call(arguments, 2, arguments.length);
   var labelText;
 
   assert.equal(inputs.length, values.length, 'expected ' + values.length + ' inputs: (' + values.join(', ') + ')');


### PR DESCRIPTION
The `bind` helper has always been private, and is now removed in 1.11.
We can just use a template + computed to get what we want.