### PR TITLE
Use get for adapter.namespace

### DIFF
--- a/addon/stores/admin.js
+++ b/addon/stores/admin.js
@@ -3,7 +3,8 @@ import DS from 'ember-data';
 
 const {
   getOwner,
-  isEmpty
+  isEmpty,
+  get
 } = Ember;
 
 const {
@@ -20,8 +21,8 @@ export default Store.extend({
       const adapter = this._super(type);
       const adminService = getOwner(this).lookup('service:admin');
 
-      if (adapter.get('namespace')) {
-        namespaces = adapter.get('namespace').split('/');
+      if (get(adapter, 'namespace')) {
+        namespaces = get(adapter, 'namespace').split('/');
       }
 
       namespaces.push(adminService.namespace);

--- a/addon/stores/admin.js
+++ b/addon/stores/admin.js
@@ -20,8 +20,8 @@ export default Store.extend({
       const adapter = this._super(type);
       const adminService = getOwner(this).lookup('service:admin');
 
-      if (adapter.namespace) {
-        namespaces = adapter.namespace.split('/');
+      if (adapter.get('namespace')) {
+        namespaces = adapter.get('namespace').split('/');
       }
 
       namespaces.push(adminService.namespace);

--- a/tests/dummy/app/adapters/dog.js
+++ b/tests/dummy/app/adapters/dog.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import ApplicationAdapter from './application';
+
+const {
+  computed
+} = Ember;
+
+export default ApplicationAdapter.extend({
+  namespace: computed(function() {
+    return '';
+  })
+});


### PR DESCRIPTION
Fix #70 

- Add adapter for the dog model with namespace as a computed property (which makes original tests fail).
- Fixeissue by using `adapter.get('namespace')` instead of `adapter.namespace` in `store/admin.js`