### PR TITLE
Update to Ember 2.8

### DIFF
--- a/addon/controllers/admin.js
+++ b/addon/controllers/admin.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { contains, removeObject } from 'ember-admin/utils/array';
+import { includes, removeObject } from 'ember-admin/utils/array';
 
 const {
   get,
@@ -17,15 +17,15 @@ export default Controller.extend({
 
     return get(this, 'model').reduce(function(collection, name) {
       if (includedModels) {
-        if (contains(includedModels, name)) {
+        if (includes(includedModels, name)) {
           collection.push(name);
         }
 
-        if (excludedModels && contains(excludedModels, name)) {
+        if (excludedModels && includes(excludedModels, name)) {
           removeObject(collection, name);
         }
       } else if (excludedModels) {
-        if (!contains(excludedModels, name)) {
+        if (!includes(excludedModels, name)) {
           collection.push(name);
         }
       } else {

--- a/addon/mixins/model-records/columns.js
+++ b/addon/mixins/model-records/columns.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import RecordTypeMixin from 'ember-admin/mixins/model-records/model-record';
-import { contains } from 'ember-admin/utils/array';
+import { includes } from 'ember-admin/utils/array';
 
 const {
   Mixin,
@@ -11,8 +11,8 @@ const {
   getOwner
 } = Ember;
 
-function columnContains(columnType, parameter) {
-  return columnType && contains(columnType, parameter);
+function columnIncludes(columnType, parameter) {
+  return columnType && includes(columnType, parameter);
 }
 
 export default Mixin.create(RecordTypeMixin, {
@@ -47,22 +47,22 @@ export default Mixin.create(RecordTypeMixin, {
     /*jshint +W024 */
 
     if (adminIncludedColumns) {
-      if (!columnContains(adminIncludedColumns[modelName], name)) {
+      if (!columnIncludes(adminIncludedColumns[modelName], name)) {
         allowColumn = false;
       }
     }
 
     if (adminExcludedColumns) {
-      if (columnContains(adminExcludedColumns[modelName], name)) {
+      if (columnIncludes(adminExcludedColumns[modelName], name)) {
         allowColumn = false;
       }
     }
 
-    if (columnContains(excludedColumns, name)) {
+    if (columnIncludes(excludedColumns, name)) {
       allowColumn = false;
     }
 
-    if (columnContains(includedColumns, name)) {
+    if (columnIncludes(includedColumns, name)) {
       allowColumn = true;
     }
 

--- a/addon/utils/array.js
+++ b/addon/utils/array.js
@@ -5,13 +5,13 @@ const {
 } = Ember;
 
 const {
-  contains: _contains,
+  includes: _includes,
   pushObject: _pushObject,
   removeObject: _removeObject
 } = emberArray();
 
-export function contains(array, ...values) {
-  return _contains.apply(emberArray(array), values);
+export function includes(array, ...values) {
+  return _includes.apply(emberArray(array), values);
 }
 
 export function pushObject(array, ...values) {

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-admin",
   "dependencies": {
-    "ember": "~2.7.0",
+    "ember": "~2.8.0",
     "ember-cli-shims": "0.1.1",
     "ember-qunit-notifications": "0.1.0",
     "pretender": "~0.10.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.0.1",
-    "ember-cli": "2.7.0",
+    "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -32,7 +32,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.7.0",
+    "ember-data": "^2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
@@ -44,7 +44,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-async-button": "0.7.0",
+    "ember-async-button": "^1.0.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-data-route": "0.2.0",
     "ember-cli-babel": "^5.1.6"


### PR DESCRIPTION
## Changes proposed in this pull request
- Updated Ember and Ember-data to the latest version, 2.8. 
- Replaced `contains` by `includes` to address a deprecation, http://emberjs.com/deprecations/v2.x/#toc_enumerable-contains
- I renamed this function `columnContains` to `columnIncludes` just to make more sense follow the same name.

